### PR TITLE
Add project. Cataclysm: Dark Days Ahead

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -92,6 +92,10 @@ projects:
     url: https://cgit.freedesktop.org/gstreamer/orc
     gh_url: https://github.com/GStreamer/orc
     reason: Depended on by Ubuntu and other free desktop operating systems
+  - name: Cataclysm: Dark Days Ahead
+    url: https://cataclysmdda.irg
+    gh_url: https://github.com/CleverRaven/Cataclysm-DDA
+    reason: Immensely popular cross-platform open-source game under continuous development for 6 years.
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Cataclysm: Dark Days Ahead**:
**https://cataclysmdda.org**

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)