### PR TITLE
Add project: Pilosa

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -139,6 +139,9 @@ projects:
   - name: ProsodyIM
     gh_url: https://github.com/bjc/prosody
     url: https://prosody.im/
+  - name: Pilosa
+    gh_url: https://github.com/pilosa/pilosa
+    url: https://www.pilosa.com/
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: Pilosa
**Project link**: https://github.com/pilosa/pilosa/

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

https://www.pilosa.com/blog/
