### PR TITLE
Add project: ReactOS

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -250,3 +250,14 @@ projects:
     latest_release_version: 0.95.8
     latest_release_date: 2017-03-11
     release_count: 92
+  - name: ReactOS
+    url: https://www.reactos.org/
+    gh_url: https://github.com/reactos/reactos
+    reason: A free Windows-compatible Operating System
+    first_release_version: 0.0.7
+    first_release_date: 1996-01-23
+    latest_release_version: 0.4.9
+    latest_release_date: 2018-07-23
+    release_count: 55  # ignore github saying >250 releases, ~80% of them are some kind of weird backup non-releases
+    release_count_zv: 55
+    star_count: 4912


### PR DESCRIPTION
A longer adherent to zerover than anything listed (22 years since 0.0.7, and still counting - only slrn is older, and it stopped counting four years ago), and over 4000 stars. Its absense is a tragedy.

Note that the GitHub releases are ~80% weird backups; I think there are 55 real ones, but I didn't double check.

Therefore, I included a release count, and hope that overrides gh_url. I also included latest_release, so it can easily be verified if 55 is still accurate; and the rest for consistency, and easier removal of gh_url if it overrides the manual release count.