### PR TITLE
Sort Emeriti Table

### DIFF
--- a/custom.py
+++ b/custom.py
@@ -129,6 +129,7 @@ def _emeritus_to_htmltable(entries):
     # table sorting js at bottom of base.html uses the stars class on
     # the heading to sort properly
     ret = ret.replace('<th>Stars</th>', '<th class="stars">Stars</th>')
+    ret = ret.replace('<th>0ver Releases</th>', '<th class="releases">0ver Releases</th>')
     ret += '\n\n'
     return ret
 


### PR DESCRIPTION
Noticed that sorting wasn't numeric for the Emeriti 0ver Releases table.

Took a stab at fixing it rather than just complaining. Though I be honest, was too lazy to actually test it out. Looks to be roughly equivalent to how stars and releases in the current list work, though.