### PR TITLE
Add Ramda

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -158,6 +158,8 @@ projects:
     gh_url: https://github.com/bup/bup
   - name: You-Get
     gh_url: https://github.com/soimort/you-get
+  - name: Ramda
+    gh_url: https://github.com/ramda/ramda
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: Ramda
**Project link**: https://ramdajs.com/

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

<!-- Prominent uses or users, or promotional material, ideally written
for an audience not familiar with that project's particular
technologies) -->

## Citation info

https://github.com/ramda/ramda/issues/2337

---

<!--

## One more thing

Since you've made it this far, why not consider filing [a PR](https://github.com/mahmoud/zerover/pulls)?

If your suggestion is a GitHub project, it's as easy as adding 2-3
lines to the `projects.yaml` file. There are comments and plenty of
examples in the file. Here's [an edit link](https://github.com/mahmoud/zerover/edit/master/projects.yaml).

No pressure or anything, feel free to smack that submit button, too! Thanks again!

-->
