### PR TITLE
Add project: Chocolatey

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -179,6 +179,9 @@ projects:
   - name: pywinauto
     url: http://pywinauto.github.io/
     gh_url: https://github.com/pywinauto/pywinauto
+  - name: Chocolatey
+    url: https://chocolatey.org/
+    gh_url: https://github.com/chocolatey/choco
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
Hi, me again. Turns out Chocolatey follows the principles of 0ver as well!

Addresses #30 
## Basic info

**Project name**: Chocolatey
**Project link**: https://chocolatey.org/

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

