### PR TITLE
Add project: Nuitka

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -200,6 +200,9 @@ projects:
     gh_url: https://github.com/vlm/asn1c
   - name: React Native
     gh_url: https://github.com/facebook/react-native
+  - name: Nuitka
+    url: https://nuitka.net/
+    gh_url: https://github.com/Nuitka/Nuitka
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: Nuitka
**Project link**: https://github.com/Nuitka/Nuitka
**Author**: @kayhayen

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

2567 stars on GitHub

## Citation info

Initial commit (0.1) in 2010: https://github.com/Nuitka/Nuitka/tree/b301e534507f5a2266f4b37d991cec3ff242ede1
First git tag (0.3.11) in 2011: https://github.com/Nuitka/Nuitka/releases/tag/0.3.11
Latest release (0.6.7) in 2020: https://github.com/Nuitka/Nuitka/releases/tag/0.6.7