### PR TITLE
Add project: Teeworlds

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -227,6 +227,9 @@ projects:
     gh_url: https://github.com/digitalbazaar/forge
   - name: Stellarium
     gh_url: https://github.com/Stellarium/stellarium
+  - name: Teeworlds
+    url: https://teeworlds.com/
+    gh_url: https://github.com/teeworlds/teeworlds
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
Popular online game, 1.6k stars on Github, 0.x version since 2007

## Basic info

**Project name**: Teeworlds
**Project link**: https://github.com/teeworlds/teeworlds/ / https://teeworlds.com/

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

Popular online game, available in most Linux distributions

## Citation info

https://en.wikipedia.org/wiki/Teeworlds

---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
