### PR TITLE
Add project: Numba

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -227,6 +227,10 @@ projects:
     gh_url: https://github.com/digitalbazaar/forge
   - name: Stellarium
     gh_url: https://github.com/Stellarium/stellarium
+  - name: Numba
+    url: https://numba.pydata.org
+    gh_url: https://github.com/numba/numba
+    reason: Widely used throughout the PyData and Python scientific computing ecosystems.
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: Numba
**Project link**: https://github.com/numba/numba

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [X] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [X] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [X] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

<!-- Prominent uses or users, or promotional material, ideally written
for an audience not familiar with that project's particular
technologies) -->

* 6.5k Github stars
* 35k dependent Github repos
* Widely used in the PyData and scientific computing ecosystems