### PR TITLE
Add project: Semgrep

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -234,6 +234,9 @@ projects:
     url: https://numba.pydata.org
     gh_url: https://github.com/numba/numba
     reason: Widely used throughout the PyData and Python scientific computing ecosystems.
+  - name: Semgrep
+    url: https://semgrep.dev/
+    gh_url: https://github.com/returntocorp/semgrep
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: Semgrep
**Project link**: https://github.com/returntocorp/semgrep

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [x] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

- https://r2c.dev/blog/2020/introducing-semgrep-and-r2c/
- https://en.wikipedia.org/wiki/Semgrep

## Citation info

<!-- For manually entered/non-GitHub project entries, please put any links
or notes about research here. -->

---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
