### PR TITLE
Remove project: VS Code C++ extension

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -175,10 +175,6 @@ projects:
   - name: wkhtmltopdf
     url: https://wkhtmltopdf.org/
     gh_url: https://github.com/wkhtmltopdf/wkhtmltopdf
-  - name: VS Code C/C++ extension
-    url: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools
-    gh_url: https://github.com/microsoft/vscode-cpptools
-    reason: Created by Microsoft and with almost 8 million installs, this is the standard extension you want if working with C or C++ in VS Code.
   - name: pywinauto
     url: http://pywinauto.github.io/
     gh_url: https://github.com/pywinauto/pywinauto


### PR DESCRIPTION
<!--

Thanks for considering contributing to ZeroVer! If you're not
adding a ZeroVer project, you can stop reading now and
delete this whole template.

---

(Please title your PR `"Add project: <project name>"`)

-->

## Basic info

**Project name**: VS Code C/C++ Extension (remove)
**Project link**:

## Qualifications

This project transitioned to 1.0 in 2020 and should be removed from the list.