### PR TITLE
Add project: zoxide

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -263,6 +263,8 @@ projects:
     gh_url: https://github.com/paperjs/paper.js
   - name: Knex.js
     gh_url: https://github.com/knex/knex
+  - name: zoxide
+    gh_url: https://github.com/ajeetdsouza/zoxide
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: zoxide
**Project link**: <https://github.com/ajeetdsouza/zoxide>

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

This is my project. I had a good chuckle when I read about 0ver -- zoxide is over 1.5 years old and I still haven't "stabilized" it!

## Citation info

<!-- For manually entered/non-GitHub project entries, please put any links
or notes about research here. -->

---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
