### PR TITLE
Add project: rand

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -424,3 +424,13 @@ projects:
     latest_release_date: 2021-01-18
     release_count: 201
     star_count: 2400
+  - name: rand
+    url: https://rust-random.github.io/book/
+    gh_url: https://github.com/rust-random/rand
+    reason: The most downloaded Rust crate
+    first_release_version: 0.1.1
+    first_release_date: 2015-02-03
+    latest_release_version: 0.8.4
+    latest_release_date: 2021-06-15
+    release_count: 67
+    star_count: 881


### PR DESCRIPTION
<!--

Thanks for considering contributing to ZeroVer! If you're not
adding a ZeroVer project, you can stop reading now and
delete this whole template.

---

(Please title your PR `"Add project: <project name>"`)

-->

## Basic info

**Project name**: rand
**Project link**: https://rust-random.github.io/book/

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

<!-- Prominent uses or users, or promotional material, ideally written
for an audience not familiar with that project's particular
technologies -->

rand is the most downloaded crate on crates.io

## Citation info

<!-- For manually entered/non-GitHub project entries, please put any links
or notes about research here. -->

crates.io page: https://crates.io/crates/rand

crates.io homepage, showing rand as the most downloaded crate: https://crates.io/

---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
