### PR TITLE
Add project: esbuild

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -424,3 +424,6 @@ projects:
     latest_release_date: 2021-01-18
     release_count: 201
     star_count: 2400
+  - name: esbuild
+    url: https://esbuild.github.io
+    gh_url: https://github.com/evanw/esbuild


### PR DESCRIPTION
## Basic info

**Project name**: esbuild
**Project link**: https://github.com/evanw/esbuild

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [X] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [X] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

esbuild is a JavaScript bundler that is many orders of magnitude faster than the competition. It is between 10x and 100x faster than rollup, webpack, etc.