### PR TITLE
Add project: CalendarKit

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -460,3 +460,10 @@ projects:
     first_release_date: 2006-09-16T00:00:00
     latest_release_version: 0.9.38
     latest_release_date: 2015-05-21T00:00:00
+  - name: CalendarKit
+    url: https://github.com/richardtop/CalendarKit
+    _gh_url: https://github.com/richardtop/CalendarKit
+    first_release_version: 0.1.0
+    first_release_date: 2017-01-26T00:00:00
+    latest_release_version: 1.0.14
+    latest_release_date: 2021-10-22T00:00:00


### PR DESCRIPTION
<!--

Thanks for considering contributing to ZeroVer! If you're not
adding a ZeroVer project, you can stop reading now and
delete this whole template.

---

(Please title your PR `"Add project: <project name>"`)

-->

## Basic info

**Project name**: CalendarKit
**Project link**: https://github.com/richardtop/CalendarKit

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or (2000+ stars)
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or (coming soon)
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)


<!--

## One more thing
CalendarKit is one of the most popular iOS frameworks to help integrate calendar view into the app, it has used zero versioning from the beginning and only now I switched to version 1.0+