### PR TITLE
Remove project: Minikube

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -23,9 +23,6 @@ projects:
     reason: "Official dependency management tool from Golang. To quote the first line of the readme, 'dep is safe for production use.'"
   - name: Apache Kafka
     gh_url: https://github.com/apache/kafka
-  - name: Minikube
-    gh_url: https://github.com/kubernetes/minikube
-    reason: Official kubernetes project with a logo, but no major release.
   - name: Arrow (Python)
     gh_url: https://github.com/crsmithdev/arrow
   - name: NeoVIM


### PR DESCRIPTION
Already in version 1.24: https://github.com/kubernetes/minikube/releases/tag/v1.24.0