### PR TITLE
Add project: pbkit

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -293,6 +293,9 @@ projects:
   - name: Pyre
     url: https://pyre-check.org
     gh_url: https://github.com/facebook/pyre-check
+  - name: pbkit
+    url: https://pbkit.dev/
+    gh_url: https://github.com/pbkit/pbkit
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: pbkit
**Project link**: https://pbkit.dev/

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [ ] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

<!-- Prominent uses or users, or promotional material, ideally written
for an audience not familiar with that project's particular
technologies -->
- pbkit vscode extension has over 3k times installs in vscode marketplace

## Citation info

<!-- For manually entered/non-GitHub project entries, please put any links
or notes about research here. -->

---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
