### PR TITLE
Remove ClamAV as it hit 1.0.0 on 2022-11-28

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -155,8 +155,6 @@ projects:
     gh_url: https://github.com/qtile/qtile
   - name: autokey
     gh_url: https://github.com/autokey/autokey
-  - name: ClamAV Antivirus
-    gh_url: https://github.com/Cisco-Talos/clamav-devel
   - name: bup
     gh_url: https://github.com/bup/bup
   - name: You-Get


### PR DESCRIPTION
After 20 years, ClamAV finally released version 1.0.0 on the 28th of November 2022 and as such is leaving the 0ver versioning scheme behind. The last version before that was 0.105.

Link to release notes:

  * https://github.com/Cisco-Talos/clamav/releases/tag/clamav-1.0.0

Archive links:

  * https://web.archive.org/web/20221205084855/https://github.com/Cisco-Talos/clamav/releases/tag/clamav-1.0.0
  * https://archive.ph/tCIO7

News article:

  * https://www.theregister.com/2022/12/01/clamav_puts_out_version_1/