### PR TITLE
Add graphile-worker

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -290,6 +290,9 @@ projects:
   - name: Pyre
     url: https://pyre-check.org
     gh_url: https://github.com/facebook/pyre-check
+  - name: graphile-worker
+    url: https://www.graphile.org/
+    gh_url: https://github.com/graphile/worker
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: graphile-worker
**Project link**: https://github.com/graphile/worker

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
  - 0.14.0 just released with huge breaking changes.
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
   - 1.3k
- [x] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
  - Kind of: Crowd-funded open-source software: https://www.graphile.org/
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)
  - Worker queue, so core infra.
