### PR TITLE
projects.yaml: Add Seaborn

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -311,6 +311,9 @@ projects:
   - name: CorsixTH
     url: https://corsixth.com
     gh_url: https://github.com/CorsixTH/CorsixTH
+  - name: seaborn
+    url: https://seaborn.pydata.org/
+    gh_url: https://github.com/mwaskom/seaborn
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: Seaborn
**Project link**: https://github.com/mwaskom/seaborn

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning scheme can obviously be used by everyone, but not every usage is necessarily notable. For Seaborn, the following criteria apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure: 11k+ GitHub stars
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

Seaborn is a statistical data visualization library in Python that is built on top of Matplotlib. It provides a high-level interface for drawing attractive and informative statistical graphics. The wide exposure of Seaborn is evident from its substantial number of GitHub stars and its frequent usage in data analysis and visualization tasks within the Python community.

## Citation info

The notability of Seaborn can be assessed through its GitHub repository and its widespread use in various data science and statistical computing projects. Its GitHub repository, along with the star count, and its extensive documentation and community engagement, reflect its maturity and infrastructural importance.

---

Closes #164.