### PR TITLE
chore: Bump Window Maker from 0.95.8 to 0.96.0

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -473,9 +473,9 @@ projects:
     wp_url: https://en.wikipedia.org/wiki/Window_Maker
     first_release_date: 1997-01-01 # exact date unknown
     first_release_version: 0.0.3
-    latest_release_version: 0.95.8
-    latest_release_date: 2017-03-11
-    release_count: 92
+    latest_release_version: 0.96.0
+    latest_release_date: 2023-08-05
+    release_count: 94
   - name: ReactOS
     url: https://www.reactos.org/
     _gh_url: https://github.com/reactos/reactos # underscore prefix prevents overriding data below


### PR DESCRIPTION
Window Maker has been updated between 2017 and 2023 with two additional releases. Updated the projects list to reflect the latest.

https://github.com/window-maker/wmaker/tags

I was surprised to see Window Maker in the list with updates as recent as 2017. Oh, nostalgia. 

When I clicked through, I noticed the more recent releases.

