### PR TITLE
Add project: Mihon

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -296,6 +296,10 @@ projects:
   #  gh_url: https://github.com/tachiyomiorg/tachiyomi
   #  reason: Rewrite is supposed to release as 1.0.0, but it has been stale and in progress for several years with no finish line in sight.
   #  dead: https://tachiyomi.org/news/2024-01-13-goodbye / https://pastebin.com/ScYsKtia
+  - name: Mihon
+    url: https://mihon.app/
+    gh_url: https://github.com/mihonapp/mihon
+    reason: Spiritual succesor of Tachiyomi. As such follows its versioning convention.
   - name: python-dotenv
     url: https://github.com/theskumar/python-dotenv
     gh_url: https://github.com/theskumar/python-dotenv


### PR DESCRIPTION
## Basic info

**Project name**: Mihon
**Project link**: https://github.com/mihonapp/mihon

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [X] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [X] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info
Spiritual succesor of Tachiyomi. As such follows its versioning convention.

## Citation info
N/A
