### PR TITLE
Add project: FreeCAD

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -355,6 +355,11 @@ projects:
   - name: Pint
     url: https://pint.readthedocs.io
     gh_url: https://github.com/hgrecco/pint
+  - name: FreeCAD
+    url: https://www.freecad.org/
+    gh_url: https://github.com/FreeCAD/FreeCAD
+    first_release_date: 2002-10-29
+    first_release_version: 0.0.1
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
<!--

Thanks for considering contributing to ZeroVer! If you're not
adding a ZeroVer project, you can stop reading now and
delete this whole template.

---

(Please title your PR `"Add project: <project name>"`)

-->

## Basic info

**Project name**: FreeCAD
**Project link**: https://www.freecad.org/

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info
FreeCAD is likely the most mature free software 3D modeling software for CAD (Computer Aided Design) applications. It has been in development since at least 2002, competing with industry giants such as CATIA, Inventor or SolidWorks, who have all long adopted inferior, calendar-based versioning schemes.

## Citation info
Information on the initial release date and version was acquired from https://en.wikipedia.org/wiki/FreeCAD

---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
