### PR TITLE
Add project: transformers

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -613,3 +613,12 @@ projects:
     latest_release_version: 0.20.0
     # technically on github, but has a weird monorepo version tagging scheme that'll need code to handle
     # gh_url: https://github.com/rustsec/rustsec
+  - name: transformers
+    url: https://hackage.haskell.org/package/transformers
+    repo_url: https://hub.darcs.net/ross/transformers
+    first_release_date: 2009-01-05
+    first_release_version: 0.0.0.0 # Now *they* understand the power of zerover.
+    latest_release_date: 2023-08-01
+    latest_release_version: 0.6.1.1
+    release_count: 39
+    reason: 11444 reverse dependencies on Hackage, including GHC itself.


### PR DESCRIPTION
The Haskell ecosystem is a gold mine of these, if anyone wanted to farm for them.

## Basic info

**Project name**: transformers
**Project link**: https://hackage.haskell.org/package/transformers
VC link: https://hub.darcs.net/ross/transformers

## Qualifications

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

11444 reverse dependencies on Hackage. The compiler itself depends on it.

## One more thing

Although the first Hackage release is "only" from 2009, the package's history goes back a lot further than that. The repository goes back to 2004, and even then, it wasn't a new project; it was just factored out of another, older project.