### PR TITLE
Add project: Tactical RMM

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -14,6 +14,9 @@
 projects:
   # GitHub projects are at the top for convenience
   # Up-to-date details are filled in automatically by tools/gen_entry_json.py
+  - name: Tactical RMM
+    url: https://docs.tacticalrmm.com
+    gh_url: https://github.com/amidaware/tacticalrmm
   - name: semver (Rust)
     gh_url: https://github.com/steveklabnik/semver
     reason: The irony. # kudos to David R. MacIver

--- a/projects.yaml
+++ b/projects.yaml
@@ -17,6 +17,7 @@ projects:
   - name: Tactical RMM
     url: https://docs.tacticalrmm.com
     gh_url: https://github.com/amidaware/tacticalrmm
+    reason: One of those forever in beta software even if it is used in critical infrastructure.
   - name: semver (Rust)
     gh_url: https://github.com/steveklabnik/semver
     reason: The irony. # kudos to David R. MacIver


### PR DESCRIPTION
<!--

Thanks for considering contributing to ZeroVer! If you're not
adding a ZeroVer project, you can stop reading now and
delete this whole template.

---

(Please title your PR `"Add project: Tactical RMM"`)

-->

## Basic info

**Project name**: Tactical RMM
**Project link**: docs.tacticalrmm.com

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [X] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [X] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [X] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [X] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

Used by a bunch of MSP as the only "source available" RMM on the market.

## Citation info

https://docs.tacticalrmm.com/
https://github.com/amidaware/tacticalrmm



---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
