### PR TITLE
Add project: atlantis

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -388,6 +388,9 @@ projects:
   - name: Create
     url: https://createmod.net/
     gh_url: https://github.com/Creators-of-Create/Create
+  - name: atlantis
+    url: https://www.runatlantis.io/
+    gh_url: https://github.com/runatlantis/atlantis
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
## Basic info

**Project name**: atlantis
**Project link**: https://github.com/runatlantis/atlantis

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

Terraform automation tool. Set it up myself in a small startup back in 2019. Few companies later, was talking with coworker regarding Terraform automation and someone mentioned "atlantis". Checked the project again and it still 0ver.
