### PR TITLE
Add Project: Nushell

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -395,6 +395,9 @@ projects:
   - name: atlantis
     url: https://www.runatlantis.io/
     gh_url: https://github.com/runatlantis/atlantis
+  - name: Nushell
+    url: https://www.nushell.sh
+    gh_url: https://github.com/nushell/nushell
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
<!--

Thanks for considering contributing to ZeroVer! If you're not
adding a ZeroVer project, you can stop reading now and
delete this whole template.

---

(Please title your PR `"Add project: <project name>"`)

-->

## Basic info

**Project name**: Nushell
**Project link**: <https://www.nushell.sh>

Nushell is an alternative shell that has been around since 2019.
It has a **logo**, dedicated **website**, **32.7k stars** as of Nov 2024 and mature enough to be used as a daily driver.
I'm sending this PR to celebrate its recent [**v0.100.0 release**](https://www.nushell.sh/blog/2024-11-12-nushell_0_100_0.html).

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)
