### PR TITLE
Add project: Thanos

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -649,3 +649,11 @@ projects:
     latest_release_version: 0.6.1.1
     release_count: 39
     reason: 11444 reverse dependencies on Hackage, including GHC itself.
+  - name: Thanos
+    url: https://thanos.io
+    repo_url: https://github.com/thanos-io/thanos
+    first_release_date: 2018-05-18
+    first_release_version: 0.1.0-rc.0 # https://github.com/thanos-io/thanos/releases/tag/v0.1.0-rc.0
+    latest_release_date: 2023-08-01
+    release_count: 122
+


### PR DESCRIPTION
Proposing [Thanos project](https://github.com/thanos-io/thanos) (CNCF's Distributed Metric Database) which I co-founded with @fabxc in late 2017 and now smarter people than us continue leading it.

Proudly [v0](https://github.com/thanos-io/thanos/releases/tag/v0.37.0) to support the [ZeroVer's](https://0ver.org/) noble cause.

## Basic info

**Project name**: Thanos
**Project link**: https://github.com/thanos-io/thanos

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [X] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [X] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [X] Relative maturity and infrastructural importance (e.g., Compiz, docutils)  (**debatable**)

## Additional notability info

* https://www.cncf.io/projects/thanos/
* KubeCon EU 2023 talk: https://www.youtube.com/watch?v=2GokLB5_VfY
