### PR TITLE
Add project: Discord for Linux and macOS. Ref #191

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -649,3 +649,21 @@ projects:
     latest_release_version: 0.6.1.1
     release_count: 39
     reason: 11444 reverse dependencies on Hackage, including GHC itself.
+  - name: Discord for Linux
+    reason: A very popular communication platform with 200+ million monthly users, that has been version 0 since 2015.
+    wp_url: https://en.wikipedia.org/wiki/Discord
+    url: https://discord.com/api/download?platform=linux&format=tar.gz # Latest in tar.gz format
+    first_release_date: 2015-05-13 # According to Wikipedia - however according the files version 0.0.1 on Linux was compiled on 2017-01-04
+    first_release_version: 0.0.1 # https://stable.dl2.discordapp.net/apps/linux/0.0.1/discord-0.0.1.tar.gz
+    latest_release_date: 2024-12-05 # Assuming that the latest patch notes refer to this version (https://discord.com/blog/discord-patch-notes-december-5-2024)
+    latest_release_version: 0.0.77 # https://discord.com/api/download?platform=linux&format=tar.gz -> https://stable.dl2.discordapp.net/apps/linux/0.0.77/discord-0.0.77.tar.gz
+    release_count: 78
+  - name: Discord for OSX
+    reason: A very popular communication platform with 200+ million monthly users, that has been version 0 since 2015.
+    wp_url: https://en.wikipedia.org/wiki/Discord
+    url: https://discord.com/api/download?platform=osx
+    first_release_date: 2015-05-13 # According to Wikipedia - however according the files version 0.0.165 on OSX was compiled on 2015-03-23
+    first_release_version: 0.0.165 # https://stable.dl2.discordapp.net/apps/osx/0.0.165/Discord.dmg
+    latest_release_date: 2024-12-05 # Assuming that the latest patch notes refer to this version (https://discord.com/blog/discord-patch-notes-december-5-2024)
+    latest_release_version: 0.0.329 # https://discord.com/api/download?platform=osx -> https://stable.dl2.discordapp.net/apps/osx/0.0.329/Discord.dmg
+    release_count: 148


### PR DESCRIPTION
## Basic info

**Project name**: Discord (for Linux and macOS)
**Project link**:  <https://discord.com/>

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning scheme can obviously be used by everyone, but not every usage is necessarily notable. Check that the first and at least one other criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [x] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [ ] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

<!-- Prominent uses or users, or promotional material, ideally written
for an audience not familiar with that project's particular
technologies) -->

Discord is a very popular communication platform with 200+ million monthly users. While it is far from open-source and is very commercial; it does allow custom bots to interact quite in-depth with the platform through a well-documented API. It is quite customizable in terms of creating communities and has excellent moderation tools. However, Discord does not support any level of self-hosting, federation, or even built-in end-to-end encryption. All information sent on the platform is entirely unencrypted (except standard client-server encryption) and stored on Discord's servers, so use it with discretion.

## Citation info

<!-- For manually entered/non-GitHub project entries, please put any links
or notes about research here. -->

Discord is probably quite an unusual addition to 0ver, as it is closed-source and very commercial. I completely understand if this issue is closed without Discord being added. However, I do find it quite novel that they are so public with their release versioning, especially across all the different operating systems, despite their "close-source-ness."

This issue refers specifically to Discord for **Linux** and **macOS**. The current release versions of all applications are:
- Linux: [0.0.66](https://dl.discordapp.net/apps/linux/0.0.66/discord-0.0.66.tar.gz)
- macOS: [0.0.317](https://dl.discordapp.net/apps/osx/0.0.317/Discord.dmg)
- Windows: [1.0.9159](https://dl.discordapp.net/distro/app/stable/win/x64/1.0.9159/DiscordSetup.exe)
- iOS/iPhone: [244.0](https://apps.apple.com/us/app/discord-talk-play-hang-out/id985746746)
- Android [244.13 (Stable)](https://play.google.com/store/apps/details?id=com.discord)