### PR TITLE
Add project: TypeORM

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -406,6 +406,9 @@ projects:
   - name: PyVista
     url: https://docs.pyvista.org/
     gh_url: https://github.com/pyvista/pyvista
+  - name: TypeORM
+    url: http://typeorm.io/
+    gh_url: https://github.com/typeorm/typeorm
 
   # Non-GitHub projects below, manually updated
 


### PR DESCRIPTION
<!--

Thanks for considering contributing to ZeroVer! If you're not
adding a ZeroVer project, you can stop reading now and
delete this whole template.

---

(Please title your PR `"Add project: <project name>"`)

-->

## Basic info

Closes #202

**Project name**: TypeORM
**Project link**: https://github.com/typeorm/typeorm

## Qualifications

[ZeroVer](https://zerover.org)'s patent-pending zero-based versioning
scheme can obviously be used by everyone, but not every usage is
necessarily notable. Check that the first and at least one other
criterion apply:

- [x] A current ZeroVer-compliant version (`0.*`) or long history of ZeroVer usage, and
- [x] Very wide exposure (i.e., 1,000+ GitHub stars), or
- [ ] Active promotion as part of a paid product or service (e.g., Hashicorp Vault), or
- [x] Relative maturity and infrastructural importance (e.g., Compiz, docutils)

## Additional notability info

<!-- Prominent uses or users, or promotional material, ideally written
for an audience not familiar with that project's particular
technologies -->

## Citation info

<!-- For manually entered/non-GitHub project entries, please put any links
or notes about research here. -->

---

<!--

## One more thing

For the most part, the notability info above should also be in the
projects.yaml, summarized under a `"reason"` key in the project entry.

-->
