### PR TITLE
Fix project: n8n

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -451,6 +451,12 @@ projects:
   - name: n8n
     url: https://n8n.io/
     gh_url: https://github.com/n8n-io/n8n
+    first_release_date: 2019-06-24
+    first_release_version: 0.2.0
+    latest_release_date: 2024-12-19
+    latest_release_version: 1.73.1
+    first_nonzv_release_date: 2023-06-27
+    last_zv_release_version: 0.234.0
 
   # Non-GitHub projects below, manually updated
   - name: ASCEND

--- a/projects.yaml
+++ b/projects.yaml
@@ -451,10 +451,9 @@ projects:
   - name: n8n
     url: https://n8n.io/
     gh_url: https://github.com/n8n-io/n8n
+    emeritus: true
     first_release_date: 2019-06-24
     first_release_version: 0.2.0
-    latest_release_date: 2024-12-19
-    latest_release_version: 1.73.1
     first_nonzv_release_date: 2023-06-27
     last_zv_release_version: 0.234.0
 


### PR DESCRIPTION
Closes #241

[n8n's tags](https://github.com/n8n-io/n8n/tags) can't be scanned automatically due to the prefix (#237 would fix). For now I hardcoded the release information.

This prompted a couple questions:
- Should n8n even be in this list? It was 0ver for 4 years (2019-2023), and it was only added to the list [3 days ago](https://github.com/mahmoud/zerover/pull/229).
- Do you consider the last 0ver release the newest 0ver release or the one preceding the first non-0ver release? Because lot's of times I see repos publishing many 0ver releases past their first non-0ver release (for fixes/patches and such).