### PR TITLE
Remove fail2ban

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -149,8 +149,6 @@ projects:
   - name: Pilosa
     gh_url: https://github.com/pilosa/pilosa
     url: https://www.pilosa.com/
-  - name: fail2ban
-    gh_url: https://github.com/fail2ban/fail2ban
   - name: qtile
     gh_url: https://github.com/qtile/qtile
   - name: autokey


### PR DESCRIPTION
Fail2ban is at 1.1.0 and has a >0 release since 2022