### PR TITLE
Fix more manual entries to be 0ver

### DIFF
--- a/tools/gen_projects_json.py
+++ b/tools/gen_projects_json.py
@@ -270,9 +270,10 @@ def fetch_entries(
             if is_zerover is not None:
                 is_zerover = not is_zerover
             else:
-                is_zerover = info.get("last_zv_release_version") is not None
-                if is_zerover is None:
-                    is_zerover = False
+                is_zerover = (
+                    info.get("last_zv_release_version") is not None
+                    or info.get("latest_release_version") is not None
+                )
         
         info["is_zerover"] = is_zerover
 


### PR DESCRIPTION
`README.md` indicates that `latest_release_version` should be set for ZeroVer projects that aren't from GitHub or that have an unusual tagging system.  However, a number of projects in that situation were being incorrectly listed as emeritus:

  ASCEND
  Cataclysm: Dark Days Ahead
  Compiz
  Dash
  Discord for Linux
  Discord for OSX
  JED
  MAME
  OpenStreetMap API/website
  PuTTY
  Tiny C Compiler
  XeTeX
  distlib
  docutils
  gettext
  three.js
  transformers