### PR TITLE
Move Prosody to emeritus status, update metadata

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -144,8 +144,15 @@ projects:
   - name: Sway Window Manager
     gh_url: https://github.com/swaywm/sway
   - name: ProsodyIM
-    gh_url: https://github.com/bjc/prosody
+    repo_url: https://hg.prosody.im/trunk
     url: https://prosody.im/
+    emeritus: true
+    release_count_zv: 56
+    first_release_date: 2008-12-04
+    first_release_version: 0.1.0
+    first_nonzv_release_date: 2025-03-17
+    first_nonzv_release_version: 13.0.0
+    last_zv_release_version: 0.12.5
   - name: Pilosa
     gh_url: https://github.com/pilosa/pilosa
     url: https://www.pilosa.com/


### PR DESCRIPTION
Prosody left 0ver status today with the [announcement of Prosody 13.0.0](https://blog.prosody.im/prosody-13.0.0-released/).

The Prosody repo was never on Github, and this was linking to a third-party mirror of the repository. Now that the 0ver-related project metadata is not really going to change anyway, I've switched it to point to the official repo and manually entered all the relevant keys into projects.yaml.

The data for the keys can be verified at https://prosody.im/doc/release/ and https://hg.prosody.im/trunk/tags

Farewell 0ver, it was fun while it lasted, but alas, all good things must come to an end! :'(