### PR TITLE
Remove project: scikit-learn

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -74,8 +74,6 @@ projects:
     gh_url: https://github.com/pytorch/pytorch
   - name: HTTPie
     gh_url: https://github.com/jakubroztocil/httpie
-  - name: scikit-learn
-    gh_url: https://github.com/scikit-learn/scikit-learn
   - name: certbot
     gh_url: https://github.com/certbot/certbot
   - name: sshuttle


### PR DESCRIPTION
Scikit-learn released 1.0 in 2021: https://github.com/scikit-learn/scikit-learn/releases/tag/1.0

It is currently on 1.6.1: https://github.com/scikit-learn/scikit-learn/releases