### PR TITLE
Update Cartopy docs url

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -372,7 +372,7 @@ projects:
     url: https://seaborn.pydata.org/
     gh_url: https://github.com/mwaskom/seaborn
   - name: Cartopy
-    url: https://scitools.org.uk/cartopy/docs/latest/
+    url: https://cartopy.readthedocs.io/stable/
     gh_url: https://github.com/SciTools/cartopy
   - name: fzf
     gh_url: https://github.com/junegunn/fzf


### PR DESCRIPTION
Cartopy’s docs moved last year, and likely the redirect will stop working at some point.